### PR TITLE
Implement Database Backups

### DIFF
--- a/predictive_punter/command.py
+++ b/predictive_punter/command.py
@@ -29,17 +29,21 @@ class Command:
         """Return a dictionary of configuration values based on the provided command line arguments"""
         
         config = {
-            'database_uri': 'mongodb://localhost:27017/predictive_punter',
-            'date_from':    datetime.now(),
-            'date_to':      datetime.now(),
-            'redis_uri':    'redis://localhost:6379/predictive_punter'
+            'backup_database':  False,
+            'database_uri':     'mongodb://localhost:27017/predictive_punter',
+            'date_from':        datetime.now(),
+            'date_to':          datetime.now(),
+            'redis_uri':        'redis://localhost:6379/predictive_punter'
         }
 
-        opts, args = getopt(args, 'd:r:', ['database-uri=', 'redis-uri='])
+        opts, args = getopt(args, 'bd:r:', ['backup-database', 'database-uri=', 'redis-uri='])
 
         for opt, arg in opts:
 
-            if opt in ('-d', '--database-uri'):
+            if opt in ('-b', '--backup-database'):
+                config['backup_database'] = True
+
+            elif opt in ('-d', '--database-uri'):
                 config['database_uri'] = arg
 
             elif opt in ('-r', '--redis-uri'):
@@ -55,7 +59,11 @@ class Command:
     def __init__(self, *args, **kwargs):
 
         database_client = pymongo.MongoClient(kwargs['database_uri'])
-        database = database_client.get_default_database()
+        self.database = database_client.get_default_database()
+
+        self.backup_database_name = None
+        if kwargs['backup_database'] == True:
+            self.backup_database_name = self.database.name + '_backup'
 
         http_client = None
         try:
@@ -70,7 +78,21 @@ class Command:
 
         scraper = punters_client.Scraper(http_client, html_parser)
         
-        self.provider = racing_data.Provider(database, scraper)
+        self.provider = racing_data.Provider(self.database, scraper)
+
+    def backup_database(self):
+        """Backup the database if backup_database is available"""
+        
+        if self.backup_database_name is not None:
+            self.database.client.drop_database(self.backup_database_name)
+            self.database.client.admin.command('copydb', fromdb=self.database.name, todb=self.backup_database_name)
+
+    def restore_database(self):
+        """Restore the database if backup_database is available"""
+
+        if self.backup_database_name is not None:
+            self.database.client.drop_database(self.database.name)
+            self.database.client.admin.command('copydb', fromdb=self.backup_database_name, todb=self.database.name)
 
     def process_collection(self, collection, target):
         """Asynchronously process all items in collection via target"""
@@ -92,7 +114,15 @@ class Command:
     def process_date(self, date):
         """Process all racing data for the specified date"""
 
-        self.process_collection(self.provider.get_meets_by_date(date), self.process_meet)
+        try:
+            self.process_collection(self.provider.get_meets_by_date(date), self.process_meet)
+
+        except BaseException:
+            self.restore_database()
+            raise
+
+        else:
+            self.backup_database()
 
     def process_meet(self, meet):
         """Process the specified meet"""


### PR DESCRIPTION
Add a '-b/--backup-database' option to the scrape command that, when specified, will cause the database to be backed up to database_uri + '_backup' after every date successfully processed, as well as restoring from the backup if an exception occurs while processing any given date.

(closes #11)
